### PR TITLE
Eh dev/organization data change

### DIFF
--- a/web-api/src/main/resources/db/migration/V1.9__Add_organization_col_url_not_null.sql
+++ b/web-api/src/main/resources/db/migration/V1.9__Add_organization_col_url_not_null.sql
@@ -1,1 +1,2 @@
+UPDATE organization SET url = '' WHERE url IS NULL;
 ALTER TABLE organization ALTER COLUMN url SET NOT NULL;

--- a/web-api/src/main/resources/db/migration/V1.9__Add_organization_col_url_not_null.sql
+++ b/web-api/src/main/resources/db/migration/V1.9__Add_organization_col_url_not_null.sql
@@ -1,0 +1,1 @@
+ALTER TABLE organization ALTER COLUMN url SET NOT NULL;


### PR DESCRIPTION
Added a new data migration file which affects organization url data in YTI. From now on, when new organization is created by user or an application entity, it needs to define the url information. A blank value or empty string is ok so this change was made so that the entity creating an organization needs to define url information or leave an empty text on user input on purpose at the user interface.

There might be some cases in yti application environments that organizations URL has NULL values so these will be changed to empty text values by assumption that NULL values were defined because the entity creating organization did not know or want to give the url information. 