### PR TITLE
YTI-1622 Fix settings for generating typescript

### DIFF
--- a/web-api/build.gradle
+++ b/web-api/build.gradle
@@ -161,6 +161,7 @@ apina {
     blackBoxClasses = [/org\.dalesbred\..+/, /java\.time\..+/]
     enumMode = 'STRING_UNION'
     typeWriteMode = 'CLASS'
+    endpoints = [/fi\.vm\.yti\.groupmanagement\.controller\..+/]
 }
 
 tasks.findByPath(":frontend:installDependencies").dependsOn apina


### PR DESCRIPTION
As a default behaviour, all classes with `@RestController` annotation will be processed for typescript generation. However, this included also some classes from swagger library and that caused an error during parsing. Restricted the scope to fi.vm.yti.groupmanagement.controller package 